### PR TITLE
implement AddSlice to mitigate cgo call overhead

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,41 @@
+package gocroaring_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/RoaringBitmap/gocroaring"
+)
+
+var ordered []uint32
+var random []uint32
+
+func init() {
+	var i uint32
+	for i = 0; i < 500000; i++ {
+		ordered = append(ordered, i)
+		random = append(random, uint32(rand.Int31n(1e6)))
+	}
+}
+
+func benchmarkAdd(b *testing.B, sl []uint32) {
+	for n := 0; n < b.N; n++ {
+		rb1 := gocroaring.NewBitmap()
+		for _, i := range sl {
+			rb1.Add(i)
+		}
+	}
+}
+
+func benchmarkAddMany(b *testing.B, sl []uint32) {
+	for n := 0; n < b.N; n++ {
+		rb1 := gocroaring.NewBitmap()
+		rb1.AddSlice(sl)
+	}
+}
+
+func BenchmarkAddRandom(b *testing.B)  { benchmarkAdd(b, random) }
+func BenchmarkAddOrdered(b *testing.B) { benchmarkAdd(b, ordered) }
+
+func BenchmarkAddManyRandom(b *testing.B)  { benchmarkAddMany(b, random) }
+func BenchmarkAddManyOrdered(b *testing.B) { benchmarkAddMany(b, ordered) }

--- a/gocroaring_test.go
+++ b/gocroaring_test.go
@@ -21,6 +21,24 @@ func TestSimpleCard(t *testing.T) {
 	}
 }
 
+func TestAddMany(t *testing.T) {
+	rb1 := NewBitmap()
+	sl := []uint32{1, 2, 3, 6, 7, 8, 20, 44444}
+	rb1.AddSlice(sl)
+
+	if int(rb1.GetCardinality()) != len(sl) {
+		t.Errorf("cardinality: expected %d, got %d", rb1.GetCardinality(), len(sl))
+	}
+	if rb1.Contains(5) {
+		t.Error("didn't expect to contain 5")
+	}
+	for _, v := range sl {
+		if !rb1.Contains(v) {
+			t.Errorf("expected to contain %d", v)
+		}
+	}
+}
+
 func TestFancier(t *testing.T) {
 	rb1 := NewBitmap()
 	rb1.Add(1)


### PR DESCRIPTION
On my machine the benchmarking looks like this:

```
BenchmarkAddRandom-4                  10     102216571 ns/op
BenchmarkAddOrdered-4                 20      87322851 ns/op
BenchmarkAddManyRandom-4             100      18905099 ns/op
BenchmarkAddManyOrdered-4           1000       1576137 ns/op
PASS
```

note that I've implemented as `roaring_bitmap_of_ptr` and then an inplace or with the current bitmap. 
I can benchmark just adding 1-by-1 in the C function to the bitmap but thought I'd post this here in case you have any insight/preference.
