### PR TITLE
add finalizer when returning a bitmap

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -12,9 +12,9 @@ var random []uint32
 
 func init() {
 	var i uint32
-	for i = 0; i < 500000; i++ {
+	for i = 0; i < 50000; i++ {
 		ordered = append(ordered, i)
-		random = append(random, uint32(rand.Int31n(1e6)))
+		random = append(random, uint32(rand.Int31n(1e6)/200))
 	}
 }
 


### PR DESCRIPTION
even with this change, the memory use can get very high, I assume that's because no GC is triggered because all the memory is held in C. I had to use GOGC=10 to run the following code even after these changes:

``` Go
package main

import (
    "math/rand"

    "github.com/RoaringBitmap/gocroaring"
)

var ordered []uint32
var random []uint32

func init() {
    var i uint32
    for i = 0; i < 50000; i++ {
        ordered = append(ordered, i)
        random = append(random, uint32(rand.Int31n(1e6)/200))
    }
}

func main() {
    rb1 := gocroaring.NewBitmap()
    rb1.Add(ordered...)
    rb2 := gocroaring.NewBitmap()
    rb2.Add(random...)
    for true {
        x := gocroaring.And(rb2, rb1)
        _ = x
    }
}
```
