### PR TITLE
Add read and write options for the frozen bitmap format supported by  the underlying c library

### DIFF
--- a/gocroaring.go
+++ b/gocroaring.go
@@ -36,6 +36,7 @@ func New(x ...uint32) *Bitmap {
 	if len(x) > 0 {
 		ptr := unsafe.Pointer(&x[0])
 		answer = &Bitmap{C.roaring_bitmap_of_ptr(C.size_t(len(x)), (*C.uint32_t)(ptr))}
+		runtime.KeepAlive(x)
 	} else {
 		answer = &Bitmap{C.roaring_bitmap_create()}
 	}
@@ -56,6 +57,7 @@ func (rb *Bitmap) Add(x ...uint32) {
 	} else {
 		ptr := unsafe.Pointer(&x[0])
 		C.roaring_bitmap_add_many(rb.cpointer, C.size_t(len(x)), (*C.uint32_t)(ptr))
+		runtime.KeepAlive(x)
 	}
 
 }
@@ -80,6 +82,7 @@ func FastOr(bitmaps ...*Bitmap) *Bitmap {
 	}
 	b := &Bitmap{C.roaring_bitmap_or_many(C.size_t(number), (**C.struct_roaring_bitmap_s)(unsafe.Pointer(&po[0])))}
 	runtime.SetFinalizer(b, free)
+	runtime.KeepAlive(po)
 	return b
 }
 
@@ -309,6 +312,7 @@ func (rb *Bitmap) Write(b []byte) error {
 	}
 	bchar := (*C.char)(unsafe.Pointer(&b[0]))
 	C.roaring_bitmap_portable_serialize(rb.cpointer, bchar)
+	runtime.KeepAlive(b)
 	return nil
 }
 
@@ -326,6 +330,7 @@ func (rb *Bitmap) WriteFrozen(b []byte) error {
 func (rb *Bitmap) ToArray() []uint32 {
 	array := make([]uint32, rb.Cardinality())
 	C.roaring_bitmap_to_uint32_array(rb.cpointer, (*C.uint32_t)(unsafe.Pointer(&array[0])))
+	runtime.KeepAlive(array)
 	return array
 }
 
@@ -355,6 +360,7 @@ func (rb *Bitmap) String() string {
 func Read(b []byte) (*Bitmap, error) {
 	bchar := (*C.char)(unsafe.Pointer(&b[0]))
 	answer := &Bitmap{C.roaring_bitmap_portable_deserialize_safe(bchar, C.size_t(len(b)))}
+	runtime.KeepAlive(b)
 	if answer.cpointer == nil {
 		return nil, errors.New("failed to read roaring array")
 	}

--- a/gocroaring.go
+++ b/gocroaring.go
@@ -250,6 +250,11 @@ func (rb *Bitmap) SerializedSizeInBytes() int {
 	return int(C.roaring_bitmap_portable_size_in_bytes(rb.cpointer))
 }
 
+// FrozenSizeInBytes computes the frozen serialized size in bytes
+func (rb *Bitmap) FrozenSizeInBytes() int {
+	return int(C.roaring_bitmap_frozen_size_in_bytes(rb.cpointer))
+}
+
 // IntIterable allows you to iterate over the values in a Bitmap
 type IntIterable interface {
 	HasNext() bool
@@ -307,6 +312,16 @@ func (rb *Bitmap) Write(b []byte) error {
 	return nil
 }
 
+// WriteFrozen writes a serialized version of bitmap to the stream in the Frozen format
+func (rb *Bitmap) WriteFrozen(b []byte) error {
+	if len(b) < rb.FrozenSizeInBytes() {
+		return errors.New("not enough space")
+	}
+	bchar := (*C.char)(unsafe.Pointer(&b[0]))
+	C.roaring_bitmap_frozen_serialize(rb.cpointer, bchar)
+	return nil
+}
+
 // ToArray creates a new slice containing all of the integers stored in the Bitmap in sorted order
 func (rb *Bitmap) ToArray() []uint32 {
 	array := make([]uint32, rb.Cardinality())
@@ -340,6 +355,18 @@ func (rb *Bitmap) String() string {
 func Read(b []byte) (*Bitmap, error) {
 	bchar := (*C.char)(unsafe.Pointer(&b[0]))
 	answer := &Bitmap{C.roaring_bitmap_portable_deserialize_safe(bchar, C.size_t(len(b)))}
+	if answer.cpointer == nil {
+		return nil, errors.New("failed to read roaring array")
+	}
+	runtime.SetFinalizer(answer, free)
+	return answer, nil
+}
+
+// ReadFrozen reads a frozen serialized verion of the bitmap
+// this is immutable and attempting to mutate it will fail catastrophically
+func ReadFrozenView(b []byte) (*Bitmap, error) {
+	bchar := (*C.char)(unsafe.Pointer(&b[0]))
+	answer := &Bitmap{C.roaring_bitmap_frozen_view(bchar, C.size_t(len(b)))}
 	if answer.cpointer == nil {
 		return nil, errors.New("failed to read roaring array")
 	}

--- a/gocroaring.go
+++ b/gocroaring.go
@@ -323,6 +323,7 @@ func (rb *Bitmap) WriteFrozen(b []byte) error {
 	}
 	bchar := (*C.char)(unsafe.Pointer(&b[0]))
 	C.roaring_bitmap_frozen_serialize(rb.cpointer, bchar)
+	runtime.KeepAlive(b)
 	return nil
 }
 
@@ -368,11 +369,12 @@ func Read(b []byte) (*Bitmap, error) {
 	return answer, nil
 }
 
-// ReadFrozen reads a frozen serialized verion of the bitmap
+// ReadFrozenView reads a frozen serialized version of the bitmap
 // this is immutable and attempting to mutate it will fail catastrophically
 func ReadFrozenView(b []byte) (*Bitmap, error) {
 	bchar := (*C.char)(unsafe.Pointer(&b[0]))
 	answer := &Bitmap{C.roaring_bitmap_frozen_view(bchar, C.size_t(len(b)))}
+	runtime.KeepAlive(b)
 	if answer.cpointer == nil {
 		return nil, errors.New("failed to read roaring array")
 	}

--- a/gocroaring_test.go
+++ b/gocroaring_test.go
@@ -179,3 +179,19 @@ func TestStats(t *testing.T) {
 		}
 	}
 }
+
+func TestWriteFrozen(t *testing.T) {
+	rb := New()
+	rb.Add(1, 2, 3, 4, 6, 7)
+
+	// frozen serialization
+	buf := make([]byte, rb.FrozenSizeInBytes())
+	rb.WriteFrozen(buf) // we omit error handling
+
+	newrb, _ := ReadFrozenView(buf)
+	if rb.Equals(newrb) {
+		fmt.Println("I wrote the content to a byte stream in frozen format and read it back.")
+	} else {
+		t.Error("Bad read")
+	}
+}


### PR DESCRIPTION
Added this in a fork to support my usecase (prebuilding bitmaps in a go tool and then reading them with the c library as memory mapped files).

I added a read function as well, primarily to allow testing. As I noted in a comment, it will fail catastrophically if a frozen bitmap is mutated, but protecting against that would have meant changing the API and adding error returns to all of the mutation functions