### PR TITLE
add Assign Method and fix ToArray panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,3 @@
 module github.com/RoaringBitmap/gocroaring
 
 go 1.13
-

--- a/gocroaring.go
+++ b/gocroaring.go
@@ -223,6 +223,13 @@ func (rb *Bitmap) Clone() *Bitmap {
 	return b
 }
 
+// Assign let rb = x2
+func (rb *Bitmap) Assign(x2 *Bitmap) bool {
+	answer := bool(C.roaring_bitmap_overwrite(rb.cpointer, x2.cpointer))
+	runtime.KeepAlive(rb)
+	return answer
+}
+
 // And computes the intersection between two bitmaps and stores the result in the current bitmap
 func (rb *Bitmap) And(x2 *Bitmap) {
 	C.roaring_bitmap_and_inplace(rb.cpointer, x2.cpointer)

--- a/gocroaring.go
+++ b/gocroaring.go
@@ -471,8 +471,11 @@ func (rb *Bitmap) WriteFrozen(b []byte) error {
 
 // ToArray creates a new slice containing all of the integers stored in the Bitmap in sorted order
 func (rb *Bitmap) ToArray() []uint32 {
-	array := make([]uint32, rb.Cardinality())
-	C.roaring_bitmap_to_uint32_array(rb.cpointer, (*C.uint32_t)(unsafe.Pointer(&array[0])))
+	card := rb.Cardinality()
+	array := make([]uint32, card)
+	if card > 0 {
+		C.roaring_bitmap_to_uint32_array(rb.cpointer, (*C.uint32_t)(unsafe.Pointer(&array[0])))
+	}
 	runtime.KeepAlive(rb)
 	return array
 }

--- a/gocroaring_test.go
+++ b/gocroaring_test.go
@@ -328,3 +328,15 @@ func TestStatsStruct(t *testing.T) {
 		}
 	})
 }
+
+func TestAssign(t *testing.T) {
+	rb1 := New()
+	for i := 0; i < 1000000; i++ {
+		rb1.Add(uint32(i) * 10)
+	}
+	rb2 := New()
+	rb2.Assign(rb1)
+	if !rb1.Equals(rb2) {
+		t.Error("should equal")
+	}
+}

--- a/gocroaring_test.go
+++ b/gocroaring_test.go
@@ -200,6 +200,11 @@ func TestString(t *testing.T) {
 	if ans != "{1,2,3}" {
 		t.Errorf("bad string ")
 	}
+	ans = New().String()
+	fmt.Println(ans)
+	if ans != "{}" {
+		t.Errorf("bad string ")
+	}
 }
 
 func TestStats(t *testing.T) {


### PR DESCRIPTION
Assign Method is much more memory efficient

old:
Clone → wait GC (there are more than 10 minutes)

new:
r := Pool.Get()
r.Assign(x)
use r
Pool.Put(r)

it can reuse fast, especially when there are no manual Free method