### PR TITLE
Keep track of buffer for frozen views

### DIFF
--- a/gocroaring.go
+++ b/gocroaring.go
@@ -33,7 +33,7 @@ type Bitmap struct {
 
 type FrozenBitmap struct {
 	Bitmap
-	buffer []byte
+	buffer *[]byte
 }
 
 // New creates a new Bitmap with any number of initial values.
@@ -528,7 +528,7 @@ func ReadFrozenView(b []byte) (*Bitmap, error) {
 	bchar := (*C.char)(unsafe.Pointer(&b[0]))
 	answer := &FrozenBitmap{
 		Bitmap{C.roaring_bitmap_frozen_view(bchar, C.size_t(len(b)))},
-		b,
+		&b,
 	}
 	// runtime.KeepAlive(b) // The caller better do it!!!
 	if answer.cpointer == nil {

--- a/gocroaring.go
+++ b/gocroaring.go
@@ -530,7 +530,6 @@ func ReadFrozenView(b []byte) (*Bitmap, error) {
 		Bitmap{C.roaring_bitmap_frozen_view(bchar, C.size_t(len(b)))},
 		&b[0],
 	}
-	// runtime.KeepAlive(b) // The caller better do it!!!
 	if answer.cpointer == nil {
 		return nil, errors.New("failed to read roaring array")
 	}

--- a/gocroaring.go
+++ b/gocroaring.go
@@ -31,9 +31,9 @@ type Bitmap struct {
 	cpointer *C.struct_roaring_bitmap_s
 }
 
-type FrozenBitmap struct {
+type frozenBitmap struct {
 	Bitmap
-	buffer *[]byte
+	buffer *byte
 }
 
 // New creates a new Bitmap with any number of initial values.
@@ -526,9 +526,9 @@ func Read(b []byte) (*Bitmap, error) {
 //
 func ReadFrozenView(b []byte) (*Bitmap, error) {
 	bchar := (*C.char)(unsafe.Pointer(&b[0]))
-	answer := &FrozenBitmap{
+	answer := &frozenBitmap{
 		Bitmap{C.roaring_bitmap_frozen_view(bchar, C.size_t(len(b)))},
-		&b,
+		&b[0],
 	}
 	// runtime.KeepAlive(b) // The caller better do it!!!
 	if answer.cpointer == nil {

--- a/gocroaring.go
+++ b/gocroaring.go
@@ -31,6 +31,11 @@ type Bitmap struct {
 	cpointer *C.struct_roaring_bitmap_s
 }
 
+type FrozenBitmap struct {
+	Bitmap
+	buffer []byte
+}
+
 // New creates a new Bitmap with any number of initial values.
 // This function may panic if the allocation failed.
 func New(x ...uint32) *Bitmap {
@@ -516,23 +521,21 @@ func Read(b []byte) (*Bitmap, error) {
 
 // ReadFrozenView reads a frozen serialized version of the bitmap
 // this is immutable and attempting to mutate it will fail catastrophically
-// You must keep the byte buffer alive for the duration of the life of the
-// frozen bitmap (call runtime.KeepAlive(buf) after the last use of the
-// resulting bitmap):
-//
-// newrb, e := ReadFrozenView(buf)
-// do some work here
-// runtime.KeepAlive(buf) // important!!!
+// It keeps a reference to the buffer internally to make sure it's alive for
+// the complete lifetime of the view
 //
 func ReadFrozenView(b []byte) (*Bitmap, error) {
 	bchar := (*C.char)(unsafe.Pointer(&b[0]))
-	answer := &Bitmap{C.roaring_bitmap_frozen_view(bchar, C.size_t(len(b)))}
+	answer := &FrozenBitmap{
+		Bitmap{C.roaring_bitmap_frozen_view(bchar, C.size_t(len(b)))},
+		b,
+	}
 	// runtime.KeepAlive(b) // The caller better do it!!!
 	if answer.cpointer == nil {
 		return nil, errors.New("failed to read roaring array")
 	}
-	runtime.SetFinalizer(answer, free)
-	return answer, nil
+	runtime.SetFinalizer(&answer.Bitmap, free)
+	return &answer.Bitmap, nil
 }
 
 // Stats returns some statistics about the roaring bitmap.

--- a/gocroaring_test.go
+++ b/gocroaring_test.go
@@ -253,7 +253,6 @@ func TestWriteFrozen(t *testing.T) {
 		} else {
 			t.Error("Bad read")
 		}
-		runtime.KeepAlive(buf)
 	}
 	fmt.Println("ok")
 }


### PR DESCRIPTION
The current implementation for frozen views comes with a responsibility for the user to keep the backing buffer alive during the view's lifetime.
However, this is not really necessary, since the Go GC supports internal pointers and the signature expects a byte slice, which is tracked by the runtime, meaning keeping a reference of our own is enough to make sure lifetimes are respected.
The price is 8 extra bytes for the slice pointer per bitmap **view**, with regular bitmaps being unaffected.
